### PR TITLE
Extracted IRateLimitService to allow injecting a custom RateLimitService for Tests

### DIFF
--- a/lib/Extensions.cs
+++ b/lib/Extensions.cs
@@ -10,8 +10,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static IServiceCollection AddRateLimits(this IServiceCollection services)
         {
-            var instance = new RateLimitService();
-            services.AddSingleton(instance);
+            services.AddSingleton<IRateLimitService, RateLimitService>();
             return services;
         }
     }

--- a/lib/Extensions.cs
+++ b/lib/Extensions.cs
@@ -10,7 +10,12 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static IServiceCollection AddRateLimits(this IServiceCollection services)
         {
-            services.AddSingleton<IRateLimitService, RateLimitService>();
+            var rateLimitService = new RateLimitService();
+
+            services.AddSingleton<RateLimitService>(rateLimitService); // for compatibility reasons
+
+            services.AddSingleton<IRateLimitService>(rateLimitService);
+
             return services;
         }
     }

--- a/lib/IRateLimitService.cs
+++ b/lib/IRateLimitService.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace NicolasDorier.RateLimits
+{
+    public interface IRateLimitService
+    {
+        int BucketsCount { get; }
+        void SetZone(LimitRequestZone requestZone);
+        void SetZone(string requestZone);
+        Task<bool> Throttle(string zoneName, object scope = null, CancellationToken cancellationToken = default);
+    }
+}

--- a/lib/RateLimitService.cs
+++ b/lib/RateLimitService.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace NicolasDorier.RateLimits
 {
-    public class RateLimitService
+    public class RateLimitService : IRateLimitService
     {
         public RateLimitService(IDelay delay = null)
         {
@@ -21,18 +21,18 @@ namespace NicolasDorier.RateLimits
 
             internal bool Ref()
             {
-                if(_RefCount == -1)
+                if (_RefCount == -1)
                     return false;
                 Interlocked.Increment(ref _RefCount);
                 return true;
             }
             internal void Release(IDelay delay)
             {
-                if(Interlocked.Decrement(ref _RefCount) == 0)
+                if (Interlocked.Decrement(ref _RefCount) == 0)
                 {
                     delay.Wait(Bucket.LimitRequestZone.RequestRate.TimePerRequest).ContinueWith((_) =>
                     {
-                        if(Interlocked.CompareExchange(ref _RefCount, -1, 0) == 0)
+                        if (Interlocked.CompareExchange(ref _RefCount, -1, 0) == 0)
                         {
                             Bucket.Close();
                         }
@@ -48,16 +48,16 @@ namespace NicolasDorier.RateLimits
 
         public void SetZone(LimitRequestZone requestZone)
         {
-            if(requestZone == null)
+            if (requestZone == null)
                 throw new ArgumentNullException(nameof(requestZone));
             _Zones.AddOrUpdate(requestZone.Name, requestZone, (a, b) => requestZone);
         }
 
         public void SetZone(string requestZone)
         {
-            if(requestZone == null)
+            if (requestZone == null)
                 throw new ArgumentNullException(nameof(requestZone));
-            if(LimitRequestZone.TryParse(requestZone, out var zone))
+            if (LimitRequestZone.TryParse(requestZone, out var zone))
                 SetZone(zone);
             else
                 throw new FormatException("Invalid request zone");
@@ -73,29 +73,29 @@ namespace NicolasDorier.RateLimits
         /// <returns>A task completing when after throttling</returns>
         public async Task<bool> Throttle(string zoneName, object scope = null, CancellationToken cancellationToken = default)
         {
-            if(zoneName == null)
+            if (zoneName == null)
                 throw new ArgumentNullException(nameof(zoneName));
             zoneName = zoneName.Trim().ToLowerInvariant();
             BucketHandle handle = null;
             var bucketKey = (zoneName, scope);
 
-            while(true)
+            while (true)
             {
-                if(_BucketHandles.TryGetValue(bucketKey, out handle))
+                if (_BucketHandles.TryGetValue(bucketKey, out handle))
                 {
-                    if(handle.Ref())
+                    if (handle.Ref())
                     {
                         break;
                     }
                 }
                 else
                 {
-                    if(!_Zones.TryGetValue(zoneName, out var zone))
+                    if (!_Zones.TryGetValue(zoneName, out var zone))
                         throw new KeyNotFoundException($"{zoneName} is not found");
                     handle = new BucketHandle();
                     handle.Bucket = new LeakyBucket(zone, _Delay);
                     handle.Ref();
-                    if(_BucketHandles.TryAdd(bucketKey, handle))
+                    if (_BucketHandles.TryAdd(bucketKey, handle))
                     {
                         handle.Drain = DrainBucket(handle).ContinueWith((t) =>
                         {
@@ -111,7 +111,7 @@ namespace NicolasDorier.RateLimits
 
         private async Task DrainBucket(BucketHandle handle)
         {
-            while(await handle.Bucket.DrainNext())
+            while (await handle.Bucket.DrainNext())
             {
                 handle.Release(_Delay);
             }

--- a/lib/RateLimitsFilterAttribute.cs
+++ b/lib/RateLimitsFilterAttribute.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace NicolasDorier.RateLimits
 {
@@ -33,7 +34,7 @@ namespace NicolasDorier.RateLimits
 
         public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
         {
-            var rateLimitService = context.HttpContext.RequestServices.GetService(typeof(RateLimitService)) as RateLimitService;
+            var rateLimitService = context.HttpContext.RequestServices.GetService<IRateLimitService>();
             if(rateLimitService == null)
                 throw new InvalidOperationException("Rate Limits not registered, please use service.AddRateLimits() in your Startup's ConfigureService method");
 
@@ -47,7 +48,7 @@ namespace NicolasDorier.RateLimits
             }
         }
 
-        private async Task<bool> Throttle(RateLimitService rateLimitService, ActionExecutingContext context)
+        private async Task<bool> Throttle(IRateLimitService rateLimitService, ActionExecutingContext context)
         {
             return await rateLimitService.Throttle(ZoneName, GetScope(context), context.HttpContext.RequestAborted);
         }

--- a/tests/RateLimitsFilterTests.cs
+++ b/tests/RateLimitsFilterTests.cs
@@ -55,12 +55,12 @@ namespace NicolasDorier.RateLimits.Tests
                     opt.ListenLocalhost(port);
                 }).UseStartup<Startup>().Build();
                 Host.Start();
-                RateLimitService = (RateLimitService)Host.Services.GetService(typeof(RateLimitService));
+                RateLimitService = Host.Services.GetService<IRateLimitService>();
                 Client = new HttpClient();
                 Client.BaseAddress = new Uri("http://localhost:" + port);
             }
 
-            public RateLimitService RateLimitService
+            public IRateLimitService RateLimitService
             {
                 get; set;
             }

--- a/tests/Startup.cs
+++ b/tests/Startup.cs
@@ -16,7 +16,7 @@ namespace NicolasDorier.RateLimits.Tests
             services.AddRateLimits();
         }
 
-        public void Configure(IApplicationBuilder app, RateLimitService service)
+        public void Configure(IApplicationBuilder app, IRateLimitService service)
         {
             var forwardingOptions = new ForwardedHeadersOptions();
             forwardingOptions.KnownNetworks.Clear();


### PR DESCRIPTION
Hi,

We would like to have the opportunity to override the RateLimitService to have a custom implementation for our Test Cases (as the rate limit is not needed there). 

- extracted an interface from the RateLimitService 
- updated Service Collection Extension to inject RateLimitService for IRateLimitService
- changed the calls to RateLimitService to using the injected IRateLimitService. 

Thanks!

Best Regards
Sabine
